### PR TITLE
fix(ci): address Node 20 deprecation and PR push bug in progress workflow

### DIFF
--- a/.github/workflows/update-progress-report.yml
+++ b/.github/workflows/update-progress-report.yml
@@ -31,6 +31,9 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v6.0.2
+        with:
+          # PR 이벤트인 경우 머지 커밋이 아닌 브랜치의 가장 최신 커밋(tip)을 가져옵니다.
+          ref: ${{ github.event.pull_request.head.sha || github.ref }}
 
       - name: Setup Python
         uses: actions/setup-python@v6.2.0
@@ -55,7 +58,6 @@ jobs:
       - name: Detect meaningful changes
         id: diff
         run: |
-          # Use jq to compare the generated JSON ignoring the 'generated_at' timestamp
           # If we don't have a previous version, we assume it changed.
           git fetch origin master || true
           git checkout -B master origin/master || true
@@ -65,17 +67,26 @@ jobs:
             exit 0
           fi
           
-          # We need to compare the newly generated json against the last committed one
-          # So we stash the current generation, checkout the committed one, compare, then pop
           cp meta/progress/progress.json /tmp/new_progress.json
+          cp meta/progress/progress.md /tmp/new_progress.md
           
           if git cat-file -e HEAD:meta/progress/progress.json 2>/dev/null; then
             git show HEAD:meta/progress/progress.json > /tmp/old_progress.json
+            OLD_JSON_HASH=$(jq 'del(.generated_at)' /tmp/old_progress.json | sha256sum | awk '{print $1}')
+            NEW_JSON_HASH=$(jq 'del(.generated_at)' /tmp/new_progress.json | sha256sum | awk '{print $1}')
             
-            OLD_HASH=$(jq 'del(.generated_at)' /tmp/old_progress.json | sha256sum | awk '{print $1}')
-            NEW_HASH=$(jq 'del(.generated_at)' /tmp/new_progress.json | sha256sum | awk '{print $1}')
+            # Markdown 파일도 비교 (생성 시간 라인 제외)
+            if git cat-file -e HEAD:meta/progress/progress.md 2>/dev/null; then
+              git show HEAD:meta/progress/progress.md | grep -v 'Last updated:' > /tmp/old_progress.md
+              grep -v 'Last updated:' /tmp/new_progress.md > /tmp/new_progress_clean.md
+              OLD_MD_HASH=$(sha256sum /tmp/old_progress.md | awk '{print $1}')
+              NEW_MD_HASH=$(sha256sum /tmp/new_progress_clean.md | awk '{print $1}')
+            else
+              OLD_MD_HASH="none"
+              NEW_MD_HASH="new"
+            fi
             
-            if [ "$OLD_HASH" != "$NEW_HASH" ]; then
+            if [ "$OLD_JSON_HASH" != "$NEW_JSON_HASH" ] || [ "$OLD_MD_HASH" != "$NEW_MD_HASH" ]; then
               echo "changed=true" >> $GITHUB_OUTPUT
             else
               echo "changed=false" >> $GITHUB_OUTPUT
@@ -86,6 +97,7 @@ jobs:
           
           # Restore the newly generated files
           cp /tmp/new_progress.json meta/progress/progress.json
+          cp /tmp/new_progress.md meta/progress/progress.md
 
       - name: Commit changes
         if: steps.diff.outputs.changed == 'true'
@@ -96,7 +108,12 @@ jobs:
           git commit -m "meta(progress): update generated progress report"
           
           if [ "${{ github.event_name }}" == "pull_request" ]; then
-            git push origin HEAD:${{ github.event.pull_request.head.ref }}
+            # PR이 닫히는 이벤트면 푸시를 스킵 (master 브랜치 push 이벤트가 메인 갱신을 처리)
+            if [ "${{ github.event.action }}" != "closed" ]; then
+              git push origin HEAD:${{ github.event.pull_request.head.ref }}
+            else
+              echo "PR closed, skipping push to head branch."
+            fi
           else
             git push origin HEAD:${{ github.ref_name }}
           fi

--- a/changed_files.txt
+++ b/changed_files.txt
@@ -1,0 +1,3 @@
+.github/workflows/update-progress-report.yml
+docs/governance/ops-bootstrap-master-plan.md
+meta/progress/build_progress_report.py

--- a/docs/governance/ops-bootstrap-master-plan.md
+++ b/docs/governance/ops-bootstrap-master-plan.md
@@ -133,3 +133,4 @@ ReproGate는 기록 기반 엔지니어링을 지향하므로, 이 저장소 자
 현재 다음 액션은 **Wave 2 거버넌스 문서 정렬 완료**다.
 - Validator rule hardened to prevent empty Decision Records (PR #11)
 - PR #12 post-merge fix: updated progress workflow to Node 22+ and fixed PR push logic
+- PR #13 post-merge fix: integrated Codex review feedback (MD hash check, FileNotFoundError, PR checkout/push logic)

--- a/meta/progress/build_progress_report.py
+++ b/meta/progress/build_progress_report.py
@@ -33,7 +33,7 @@ def fetch_github_state_cli(repo: str, kind: str, number: int) -> str:
         cmd = ["gh", kind, "view", str(number), "--repo", repo, "--json", "state", "-q", ".state"]
         result = subprocess.run(cmd, capture_output=True, text=True, check=True)
         return result.stdout.strip().lower()
-    except subprocess.CalledProcessError:
+    except (subprocess.CalledProcessError, FileNotFoundError):
         return "not_found"
 
 

--- a/pr_body.md
+++ b/pr_body.md
@@ -1,0 +1,22 @@
+## Change Type
+- Bug Fix (CI/CD Workflow)
+
+## Why
+- PR #12에서 추가된 워크플로우 로직의 세부 결함(Codex 봇이 지적한 사항)을 보완합니다.
+
+## Linked Issue
+- N/A
+
+## Product Layer
+- CI/CD Workflow
+
+## Related Docs
+- docs/governance/ops-bootstrap-master-plan.md
+
+## Decision Record
+- PR 브랜치 대상 푸시 로직 분기 처리(`github.event.pull_request.head.ref`) 및 Closed 이벤트 대응.
+- `gh` CLI 예외 처리 강화.
+- `progress.md`의 의미 있는 변경 감지 로직 추가.
+
+## Verification
+- 로컬 스크립트(`validate_product_definition.py`) 및 Gatekeeper 검증 완료.


### PR DESCRIPTION
## Change Type
- Bug Fix (CI/CD Workflow)

## Why
- PR #12에서 추가된 워크플로우 로직의 세부 결함(Codex 봇이 지적한 사항)을 보완합니다.

## Linked Issue
- N/A

## Product Layer
- CI/CD Workflow

## Related Docs
- docs/governance/ops-bootstrap-master-plan.md

## Decision Record
- PR 브랜치 대상 푸시 로직 분기 처리(`github.event.pull_request.head.ref`) 및 Closed 이벤트 대응.
- `gh` CLI 예외 처리 강화.
- `progress.md`의 의미 있는 변경 감지 로직 추가.

## Verification
- 로컬 스크립트(`validate_product_definition.py`) 및 Gatekeeper 검증 완료.